### PR TITLE
Update main.dart

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -252,7 +252,7 @@ class _LoginPageState extends State<LoginPage> {
   Widget build(BuildContext context) {
     return SafeArea(
       child: Scaffold(
-        resizeToAvoidBottomPadding: false,
+        resizeToAvoidBottomInset: false,
         backgroundColor: Color(0xfff2f3f7),
         body: Stack(
           children: <Widget>[


### PR DESCRIPTION
The scaffold property "resizeToAvoidBottomPadding" was deprecated and changed to "resizeToAvoidBottomInset" instead.